### PR TITLE
環境変数に SECRET_KEY_BASE が必要になることを明示

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -19,6 +19,8 @@ services:
         fromDatabase:
           name: test-app-db
           property: connectionString
+      - key: SECRET_KEY_BASE
+        sync: false
     autoDeploy: false
 
 databases:


### PR DESCRIPTION
## 内容
- Render.com で Blueprints を実行した際に設定を促されるようにするように調整